### PR TITLE
Fix typo colors_MAT.json

### DIFF
--- a/data/colors_MAT.json
+++ b/data/colors_MAT.json
@@ -1,13 +1,13 @@
 {
     "PC":["#FFCC00","Plan Común"],
-    "CI":["#02CCFE","Ciencias de Ingenería"],
-    "IAA":["#C0C0C0","Ingenería Aplicada e Integración"],
+    "CI":["#02CCFE","Ciencias de Ingeniería"],
+    "IAA":["#C0C0C0","Ingeniería Aplicada e Integración"],
     "FC":["#FF6600","Formación"],
     "DEW":["#D3ED12","DEFIDER"],
     "ENG":["#B745BA","Ingles"],
     "ICMATB":["#17a617","Ciencias Basicas ICMAT"],
     "ICMATA":["#CDFFCC","Ciencias Aplicadas ICMAT"],
-    "ELI":["#264cbf","Electivo de Ingenería"],
+    "ELI":["#264cbf","Electivo de Ingeniería"],
     "ELG":["#d10000","Electivo de Gestión"],
     "COMP":["#B05800","Complementarios"]
 }

--- a/data/colors_MAT.json
+++ b/data/colors_MAT.json
@@ -4,7 +4,7 @@
     "IAA":["#C0C0C0","Ingeniería Aplicada e Integración"],
     "FC":["#FF6600","Formación"],
     "DEW":["#D3ED12","DEFIDER"],
-    "ENG":["#B745BA","Ingles"],
+    "ENG":["#B745BA","Inglés"],
     "ICMATB":["#17a617","Ciencias Basicas ICMAT"],
     "ICMATA":["#CDFFCC","Ciencias Aplicadas ICMAT"],
     "ELI":["#264cbf","Electivo de Ingeniería"],


### PR DESCRIPTION
Arreglo del error de tipeo: `Ingeniería` en vez de `Ingenería`. Ver [issue 32](https://github.com/BooterMan98/malla-interactiva/issues/32).