### PR TITLE
Cambios de Malla a Ingeniería Civil Informática [TERMINADO[

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,8 +3,8 @@ Changelog del proyecto. No es la gran cosa pero *podría* ser útil a futuro
 
 # [1.6.5]
 - Se agregó la malla que rige desde 2025 de Ingeniería Civil Informática
-  (Se dejó la malla antigua, para que alumnos que la sigan usando, no tengan problemas)
-  (Ahora en el índice habrán 2 mallas de Ingeniería Civil Informática)
+  - (Se dejó la malla antigua, para que alumnos que la sigan usando, no tengan problemas)
+  - (Ahora en el índice habrán 2 mallas de Ingeniería Civil Informática)
 
 # [1.6.4]
 - La información de contacto se ha puesto al día

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 Changelog del proyecto. No es la gran cosa pero *podría* ser útil a futuro
 
+# [1.6.5]
+- Se agregó la malla que rige desde 2025 de Ingeniería Civil Informática
+  (Se dejó la malla antigua, para que alumnos que la sigan usando, no tengan problemas)
+  (Ahora en el índice habrán 2 mallas de Ingeniería Civil Informática)
+
 # [1.6.4]
 - La información de contacto se ha puesto al día
   - Se agregó el contacto del desarrollador original del proyecto


### PR DESCRIPTION
Se agrega malla nueva de 2025, dejando la antigua para que alumnos antiguos puedan seguir su progreso.